### PR TITLE
Fixes for `is_less_than_double`

### DIFF
--- a/doc/cgreen-guide-en.asciidoc
+++ b/doc/cgreen-guide-en.asciidoc
@@ -606,6 +606,8 @@ Here are the standard constraints...
 | `begins_with_string(value)` |starts with the string 'value'
 | `is_equal_to_double(value)` |are equal to 'value' within the number of significant digits (you can set 'significant_figures_for_assert_double_are(int figures)')
 | `is_not_equal_to_double(value)` |are not equal to 'value' within the number of significant digits
+| `is_less_than_double(value)` | '< value' withing the number of significant digits
+| `is_greater_than_double(value)` | '> value' within the number of significant digits
 |=========================================================
 
 The boolean assertion macros accept an `int` value. The equality

--- a/include/cgreen/constraint.h
+++ b/include/cgreen/constraint.h
@@ -87,6 +87,12 @@ bool is_parameter(const Constraint *);
 bool constraint_is_not_for_parameter(const Constraint *, const char *);
 bool constraint_is_for_parameter(const Constraint *, const char *);
 bool constraint_is_for_parameter_in(const Constraint *, const char *);
+bool doubles_are_equal(double tried, double expected);
+bool double_is_lesser(double actual, double expected);
+bool double_is_greater(double actual, double expected);
+
+int get_significant_figures();
+void significant_figures_for_assert_double_are(int figures);
 
 #ifdef __cplusplus
     }

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -190,7 +190,7 @@ bool double_is_greater(double actual, double expected) {
 /* end wrong implementations */
 
 static double accuracy(int figures, double largest) {
-    return pow(10, 1 + (int)log10(largest) - figures);
+    return pow(10, 1 + (int)log10(fabs(largest)) - figures);
 }
 
 #ifdef __cplusplus

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -16,21 +16,6 @@ namespace cgreen {
 #endif
 
 
-#ifdef max
-#undef max
-#endif
-
-#ifdef min
-#undef min
-#endif
-
-#define max(a,b) ((a) > (b) ? (a) : (b))
-#define min(a,b) ((a) > (b) ? (b) : (a))
-
-static double accuracy(int significant_figures, double largest);
-
-static int significant_figures = 8;
-
 void assert_that_(const char *file, int line, const char *actual_string, intptr_t actual, Constraint* constraint) {
 
     char *failure_message;
@@ -102,7 +87,7 @@ void assert_that_double_(const char *file, int line, const char *expression, dou
             expression,
             constraint->name,
             constraint->expected_value_name,
-            significant_figures,
+            get_significant_figures(),
             actual,
             as_double(constraint->expected_value));
 
@@ -134,7 +119,7 @@ void assert_double_equal_(const char *file, int line, const char *expression, do
             file,
             line,
             doubles_are_equal(tried, expected),
-            "[%s] should be [%f] within %d significant figures but was [%f]\n", expression, expected, significant_figures, tried);
+            "[%s] should be [%f] within %d significant figures but was [%f]\n", expression, expected, get_significant_figures(), tried);
 }
 
 void assert_double_not_equal_(const char *file, int line, const char *expression, double tried, double expected) {
@@ -143,7 +128,7 @@ void assert_double_not_equal_(const char *file, int line, const char *expression
             file,
             line,
             ! doubles_are_equal(tried, expected),
-            "[%s] should not be [%f] within %d significant figures but was [%f]\n", expression, expected, significant_figures, tried);
+            "[%s] should not be [%f] within %d significant figures but was [%f]\n", expression, expected, get_significant_figures(), tried);
 }
 
 void assert_string_equal_(const char *file, int line, const char *expression, const char *tried, const char *expected) {
@@ -164,31 +149,10 @@ void assert_string_not_equal_(const char *file, int line, const char *expression
             "[%s] should not be [%s] but was\n", expression, show_null_as_the_string_null(expected));
 }
 
-void significant_figures_for_assert_double_are(int figures) {
-    significant_figures = figures;
-}
-
 const char *show_null_as_the_string_null(const char *string) {
     return (string == NULL ? "NULL" : string);
 }
 
-
-/* TODO: these double comparison functions should move into constraints.c/h */
-bool doubles_are_equal(double tried, double expected) {
-    return max(tried, expected) - min(tried, expected) < accuracy(significant_figures, max(tried, expected));
-}
-
-bool double_is_lesser(double actual, double expected) {
-    return expected < actual + accuracy(significant_figures, max(actual, expected));
-}
-
-bool double_is_greater(double actual, double expected) {
-    return expected > actual - accuracy(significant_figures, max(actual, expected));
-}
-
-static double accuracy(int figures, double largest) {
-    return pow(10, 1 + (int)log10(fabs(largest)) - figures);
-}
 
 #ifdef __cplusplus
 } // namespace cgreen

--- a/src/assertions.c
+++ b/src/assertions.c
@@ -178,16 +178,13 @@ bool doubles_are_equal(double tried, double expected) {
     return max(tried, expected) - min(tried, expected) < accuracy(significant_figures, max(tried, expected));
 }
 
-/* there are almost certainly wrong, but can't get the neurons firing to make it right */
-/* "double" tests in all_constraints_printout and constraint_tests should all pass/fail appropriately */
 bool double_is_lesser(double actual, double expected) {
-    return actual - expected > accuracy(significant_figures, max(actual, expected));
+    return expected < actual + accuracy(significant_figures, max(actual, expected));
 }
 
 bool double_is_greater(double actual, double expected) {
-    return expected - actual > accuracy(significant_figures, max(actual, expected));
+    return expected > actual - accuracy(significant_figures, max(actual, expected));
 }
-/* end wrong implementations */
 
 static double accuracy(int figures, double largest) {
     return pow(10, 1 + (int)log10(fabs(largest)) - figures);

--- a/src/constraint.c
+++ b/src/constraint.c
@@ -6,6 +6,7 @@
 #include <cgreen/parameters.h>
 #include <cgreen/vector.h>
 #include <inttypes.h>
+#include <math.h>
 #ifndef __cplusplus
 #include <stdbool.h>
 #endif
@@ -22,6 +23,23 @@
 #ifdef __cplusplus
 namespace cgreen {
 #endif
+
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#define min(a,b) ((a) > (b) ? (b) : (a))
+
+
+static int significant_figures = 8;
+
+
+static double accuracy(int significant_figures, double largest);
 
 static bool compare_want_greater_value(Constraint *constraint, intptr_t actual);
 
@@ -580,6 +598,29 @@ bool constraint_is_for_parameter_in(const Constraint *constraint, const char *na
     return found;
 }
 
+bool doubles_are_equal(double tried, double expected) {
+    return max(tried, expected) - min(tried, expected) < accuracy(significant_figures, max(tried, expected));
+}
+
+bool double_is_lesser(double actual, double expected) {
+    return expected < actual + accuracy(significant_figures, max(actual, expected));
+}
+
+bool double_is_greater(double actual, double expected) {
+    return expected > actual - accuracy(significant_figures, max(actual, expected));
+}
+
+static double accuracy(int figures, double largest) {
+    return pow(10, 1 + (int)log10(fabs(largest)) - figures);
+}
+
+void significant_figures_for_assert_double_are(int figures) {
+    significant_figures = figures;
+}
+
+int get_significant_figures() {
+    return significant_figures;
+}
 
 #ifdef __cplusplus
 } // namespace cgreen

--- a/tests/all_constraints_printout.c
+++ b/tests/all_constraints_printout.c
@@ -5,6 +5,7 @@
 #include <cgreen/cgreen.h>
 #include <cgreen/mocks.h>
 #include <signal.h>
+#include <float.h>
 
 #ifdef __cplusplus
 using namespace cgreen;
@@ -104,8 +105,26 @@ Ensure(FailureMessage,for_equal_to_double) {
   assert_that_double(0, is_equal_to_double(1));
 }
 
+Ensure(FailureMessage,for_equal_to_double_negative) {
+  assert_that_double(-1, is_equal_to_double(-2));
+}
+
 Ensure(FailureMessage,for_not_equal_to_double) {
   assert_that_double(0, is_not_equal_to_double(0));
+}
+
+Ensure(FailureMessage,for_not_equal_to_double_negative) {
+  assert_that_double(-1, is_not_equal_to_double(-1));
+}
+
+Ensure(FailureMessage,for_is_less_than_double_with_accuracy) {
+  significant_figures_for_assert_double_are(4);
+  assert_that_double(1.0, is_less_than_double(1.0 - 1.0e-3 - DBL_EPSILON));
+}
+
+Ensure(FailureMessage,for_is_greater_than_double_with_accuracy) {
+  significant_figures_for_assert_double_are(4);
+  assert_that_double(1.0, is_greater_than_double(1.0 + 1.0e-3 + DBL_EPSILON));
 }
 
 Ensure(FailureMessage,for_assert_that) {
@@ -202,7 +221,11 @@ TestSuite *all_constraints_tests() {
     add_test_with_context(suite, FailureMessage, for_does_not_contain_string);
     add_test_with_context(suite, FailureMessage, for_begins_with_string);
     add_test_with_context(suite, FailureMessage, for_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_equal_to_double_negative);
     add_test_with_context(suite, FailureMessage, for_not_equal_to_double);
+    add_test_with_context(suite, FailureMessage, for_not_equal_to_double_negative);
+    add_test_with_context(suite, FailureMessage, for_is_less_than_double_with_accuracy);
+    add_test_with_context(suite, FailureMessage, for_is_greater_than_double_with_accuracy);
     add_test_with_context(suite, FailureMessage, for_assert_that);
     add_test_with_context(suite, FailureMessage, for_mock_called_with_unexpected_parameter_value);
     add_test_with_context(suite, FailureMessage, for_mock_called_more_times_than_expected);

--- a/tests/assertion_tests.c
+++ b/tests/assertion_tests.c
@@ -176,6 +176,8 @@ Ensure(double_differences_do_not_matter_past_significant_figures) {
     assert_that_double(1.113, is_equal_to_double(1.115));
     assert_that_double(1113, is_equal_to_double(1115));
     assert_that_double(1113000, is_equal_to_double(1115000));
+    assert_that_double(1.1199999999, is_less_than_double(1.11));
+    assert_that_double(1.11, is_greater_than_double(1.119999));
 }
 
 Ensure(can_check_equality_of_negative_floating_point_numbers) {

--- a/tests/assertion_tests.c
+++ b/tests/assertion_tests.c
@@ -178,6 +178,27 @@ Ensure(double_differences_do_not_matter_past_significant_figures) {
     assert_that_double(1113000, is_equal_to_double(1115000));
 }
 
+Ensure(can_check_equality_of_negative_floating_point_numbers) {
+    significant_figures_for_assert_double_are(3);
+    assert_that_double(-1.113, is_equal_to_double(-1.115));
+    assert_that_double(-1.13, is_not_equal_to_double(-1.15));
+}
+
+Ensure(double_one_is_less_than_two) {
+    assert_that_double(1.0, is_less_than_double(2.0));
+}
+
+Ensure(double_one_is_greater_than_zero) {
+    assert_that_double(1.0, is_greater_than_double(0.0));
+}
+
+Ensure(double_can_compare_negative_numbers) {
+    assert_that_double(1.0, is_greater_than_double(-10.0));
+    assert_that_double(-2.0, is_less_than_double(1.0));
+    assert_that_double(-21.0, is_less_than_double(-10.0));
+    assert_that_double(-11.0, is_greater_than_double(-12.0));
+}
+
 Ensure(double_differences_matter_past_significant_figures) {
     significant_figures_for_assert_double_are(4);
     assert_that_double(1.113, is_not_equal_to_double(1.115));
@@ -285,6 +306,10 @@ TestSuite *assertion_tests() {
     add_test(suite, one_should_assert_long_double_equal_to_one);
     add_test(suite, zero_should_assert_long_double_not_equal_to_one);
     add_test(suite, double_differences_do_not_matter_past_significant_figures);
+    add_test(suite, can_check_equality_of_negative_floating_point_numbers);
+    add_test(suite, double_one_is_less_than_two);
+    add_test(suite, double_one_is_greater_than_zero);
+    add_test(suite, double_can_compare_negative_numbers);
     add_test(suite, double_differences_matter_past_significant_figures);
     add_test(suite, double_assertions_can_have_custom_messages);
     add_test(suite, identical_string_copies_should_match);


### PR DESCRIPTION
I added a few tests for the double comparison functions, both passing tests and failing tests. There are both `typical` test cases as well as tight corner cases. I think `is_less_than_double` and `is_greater_than_double` are correct now.

There were also issues with comparisons of negative floating point numbers. This should be fixed as well. I've added a couple of tests for this.
